### PR TITLE
Make use of setQueryData from mutation success response

### DIFF
--- a/components/inputs/NewTweetInput.tsx
+++ b/components/inputs/NewTweetInput.tsx
@@ -15,7 +15,7 @@ const NewTweetInput = ({ text, setText, image }: Props) => {
   useEffect(() => {
     setTimeout(() => {
       textRef.current!.focus();
-    }, 250);
+    }, 150);
   }, []);
 
   return (

--- a/screens/NewTweet.tsx
+++ b/screens/NewTweet.tsx
@@ -12,7 +12,7 @@ import NewTweetInput from "../components/inputs/NewTweetInput";
 import UserPictureCircle from "../components/UserCircle";
 import { createTweet } from "../utils/Posts";
 import tw from "../utils/tailwind";
-import { Post } from "../utils/types";
+import { Post, PostRoot } from "../utils/types";
 
 interface Props {
   navigation: NavigationProp<any>;
@@ -24,8 +24,12 @@ const NewTweet = ({ navigation }: Props) => {
 
   const queryClient = useQueryClient();
   const { mutate, isLoading } = useMutation((post: Post) => createTweet(post), {
-    onSuccess: () => {
-      queryClient.invalidateQueries("tweets");
+    onSuccess: ({ data: newTweetData }) => {
+      queryClient.setQueryData(["tweets"], (data) => {
+        let oldData = data as { data: PostRoot };
+        oldData.data.posts = [newTweetData.post, ...oldData.data.posts!];
+        return data;
+      });
       navigation.goBack();
     },
   });


### PR DESCRIPTION
There's no need for query invalidation on every new tweet and making a comment, using `setQueryData` with mutation response for updating the UI:
- Making a new tweet cbf1be8010b6eb21ab853a9d914757bb11072cfd 
- Tweeting a new comment 527b79925fa35d8641be00fd608a21d46e6e7483